### PR TITLE
Krishna gift

### DIFF
--- a/app/ffi/api/immutable_data.js
+++ b/app/ffi/api/immutable_data.js
@@ -142,9 +142,9 @@ class ImmutableData extends FfiApi {
   read(readerId, offset, length) {
     const self = this;
     const executor = (resolve, reject) => {
-      const dataRefRef = ref.alloc(PointerToU8Pointer);
-      const sizeRef = ref.alloc(u64);
-      const capacityRef = ref.alloc(u64);
+      let dataRefRef = ref.alloc(PointerToU8Pointer);
+      let sizeRef = ref.alloc(u64);
+      let capacityRef = ref.alloc(u64);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           reject(err || res);

--- a/app/ffi/api/misc.js
+++ b/app/ffi/api/misc.js
@@ -80,9 +80,9 @@ class Misc extends FfiApi {
 
   _serialise(handleId, type) {
     return new Promise((resolve, reject) => {
-      const dataPointerRef = ref.alloc(PointerToU8Pointer);
-      const sizeRef = ref.alloc(size_t);
-      const capacityRef = ref.alloc(size_t);
+      let dataPointerRef = ref.alloc(PointerToU8Pointer);
+      let sizeRef = ref.alloc(size_t);
+      let capacityRef = ref.alloc(size_t);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           return reject(err || res);

--- a/app/ffi/api/structured_data.js
+++ b/app/ffi/api/structured_data.js
@@ -175,9 +175,9 @@ class StructuredData extends FfiApi {
     const executor = async (resolve, reject) => {
       try {
         const structuredDataHandleId = await self._asStructuredData(app, handleId);
-        const dataPointerRef = ref.alloc(PointerToU8Pointer);
-        const sizeRef = ref.alloc(size_t);
-        const capacityRef = ref.alloc(size_t);
+        let dataPointerRef = ref.alloc(PointerToU8Pointer);
+        let sizeRef = ref.alloc(size_t);
+        let capacityRef = ref.alloc(size_t);
         const onResult = (err, res) => {
           if (err || res !== 0) {
             return reject(err || res);


### PR DESCRIPTION
Original request:

```
        const dataPointerRef = ref.alloc(PointerToU8Pointer); // Check - On 1st look it should not be const
        const sizeRef = ref.alloc(size_t);                // Check -     "  "   "
        const capacityRef = ref.alloc(size_t);      // Check -    "   "  "

 // Call safe_core function passing the above
 // After obtaining from safe_core:

        const size = sizeRef.deref();
        const capacity = capacityRef.deref();
        const dataPointer = dataPointerRef.deref();
        let data = ref.reinterpret(dataPointer, size); // Check
        data = Buffer.concat([data]);              // Check
        self.dropVector(dataPointer, size, capacity); // Check if `data` is cloned and accessing it after dropping the vector is safe.
```

Technically, from the PoV of a C programmer, the previous approach was correct. Given the modified value was the pointee, not the pointer itself (whose value -- the address -- remained unchanged). Rust has the semantics to specify this type behaviour. I don't know if JavaScript has this type expressiveness (I guess it doesn't).
